### PR TITLE
Compile linker plugins for 64 bit

### DIFF
--- a/BUILD-gcc
+++ b/BUILD-gcc
@@ -27,7 +27,7 @@ if ! test -f .have-configure; then
     --with-hsa-runtime-lib=$HSA_RUNTIME \
     CC='gcc -m64 -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib64 \
     CXX='g++ -m64 -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib64 \
-    --enable-linker-plugin-flags='CC=gcc\ -m32\ -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib \
+    --enable-linker-plugin-flags='CC=gcc\ -m64\ -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib \
     --enable-linker-plugin-configure-flags=--host=i686-pc-linux-gnu \
     --with-sysroot= \
     $CONFIGURE_ &&

--- a/BUILD-gcc-offload-nvptx-none
+++ b/BUILD-gcc-offload-nvptx-none
@@ -28,7 +28,7 @@ if ! test -f .have-configure; then
     --enable-checking=yes \
     CC='gcc -m64 -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib64 \
     CXX='g++ -m64 -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib64 \
-    --enable-linker-plugin-flags='CC=gcc\ -m32\ -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib \
+    --enable-linker-plugin-flags='CC=gcc\ -m64\ -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib \
     --enable-linker-plugin-configure-flags=--host=i686-pc-linux-gnu \
     --with-sysroot=/nvptx-none \
     --with-build-sysroot="$T"/install/offload-nvptx-none/nvptx-none \

--- a/BUILD-gcc-offload-x86_64-intelmicemul-linux-gnu
+++ b/BUILD-gcc-offload-x86_64-intelmicemul-linux-gnu
@@ -22,7 +22,7 @@ if ! test -f .have-configure; then
     --disable-multilib \
     CC='gcc -m64 -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib64 \
     CXX='g++ -m64 -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib64 \
-    --enable-linker-plugin-flags='CC=gcc\ -m32\ -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib \
+    --enable-linker-plugin-flags='CC=gcc\ -m64\ -Wl,-rpath,'$SCB/i686-pc-linux-gnu/lib \
     --enable-linker-plugin-configure-flags=--host=i686-pc-linux-gnu \
     --with-sysroot= \
     $CONFIGURE_ &&


### PR DESCRIPTION
The linker-plugin-flags that are used to configure GCC in the build scripts
include` -m32` although GCC gets compiled with `-m64`.
On my system, this causes the compilation to fail with an error that looks like:
```/usr/bin/ld: [...]/gcc-playground/build-gcc/./gcc/liblto_plugin.so: error loading plugin: [...]/gcc-playground/build-gcc/./gcc/liblto_plugin.so: wrong ELF class: ELFCLASS32```

Replacing `-m32` with `-m64` in the linker-plugin-flags solves that issue for me.